### PR TITLE
fix: disable reload

### DIFF
--- a/src/run_server.py
+++ b/src/run_server.py
@@ -18,7 +18,7 @@ def main():
         "fastapi_server:app",
         host="0.0.0.0",
         port=8000,
-        reload=True,
+        reload=False,
         log_level="info"
     )
 


### PR DESCRIPTION
reload=True cased directory discovery issue for FastAPI server